### PR TITLE
Fix memory leak on DropColumnFamily()

### DIFF
--- a/RocksDbSharp/RocksDb.cs
+++ b/RocksDbSharp/RocksDb.cs
@@ -269,7 +269,11 @@ namespace RocksDbSharp
         {
             var cf = GetColumnFamily(name);
             Native.Instance.rocksdb_drop_column_family(Handle, cf.Handle);
-            columnFamilies.Remove(name);
+            if (columnFamilies.TryGetValue(name, out ColumnFamilyHandleInternal cfhi))
+            {
+                cfhi.Dispose();
+                columnFamilies.Remove(name);
+            }
         }
         
         public ColumnFamilyHandle GetDefaultColumnFamily()


### PR DESCRIPTION
This PR fixes memory leak occurred when `RocksDB.DropColumnFamily()` by forcing `.Dispose()` before removing db.