### PR TITLE
ci(gh-actions): automate build and test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,15 @@
+on:
+- push
+- pull_request
+
+name: Test
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [windows-latest, macos-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - run: dotnet test

--- a/tests/RocksDbSharpTest/RocksDbSharpTest.csproj
+++ b/tests/RocksDbSharpTest/RocksDbSharpTest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <LangVersion>7.2</LangVersion>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>


### PR DESCRIPTION
It automates build and test with GitHub Actions. You can see that the workflow works, [here](https://github.com/moreal/rocksdb-sharp/runs/1835576296?check_suite_focus=true). Also, it bumps the target framework of `RocksDbSharpTest` project `netcoreapp2.2` → `netcoreapp3.1` because its lifecycle ended up. See also https://github.com/actions/virtual-environments/issues/975.